### PR TITLE
(feature) Create menu model for sequelize

### DIFF
--- a/server/models/Menu.js
+++ b/server/models/Menu.js
@@ -1,0 +1,24 @@
+const menu = (sequelize, DataTypes) => {
+  const Menu = sequelize.define('menu', {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      allowNull: false,
+      primaryKey: true,
+    },
+    meals: {
+      type: DataTypes.JSON,
+      allowNull: false,
+    },
+    day: {
+      type: DataTypes.DATE,
+      allowNull: false,
+    },
+  });
+  Menu.associate = (models) => {
+    Menu.belongsTo(models.Caterer, { onDelete: 'CASCADE' });
+  };
+  return Menu;
+};
+
+export default menu;


### PR DESCRIPTION
## What does this PR do?
* Create Sequelize database model for Menu

### Changes
* Introduces a breaking change when routes are to be accessed as the directory names for the models and services have been changed from `models`, `services` to `dummyModels` and `dummyServices` respectively