### PR TITLE
(feature) Create order model for sequelize

### DIFF
--- a/server/models/Order.js
+++ b/server/models/Order.js
@@ -1,0 +1,34 @@
+const order = (sequelize, DataTypes) => {
+  const Order = sequelize.define('order', {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      allowNull: false,
+      primaryKey: true,
+    },
+    order: {
+      type: DataTypes.JSON,
+      allowNull: false,
+    },
+    amount: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    address: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    status: {
+      type: DataTypes.STRING,
+      default: 'processing',
+    },
+  });
+
+  Order.associate = (models) => {
+    Order.belongsTo(models.Caterer, { onDelete: 'CASCADE' });
+  };
+
+  return Order;
+};
+
+export default order;


### PR DESCRIPTION
## What does this PR do?
* Create Sequelize database model for Orders

### Changes
* Introduces a breaking change when routes are to be accessed as the directory names for the models and services have been changed from `models`, `services` to `dummyModels` and `dummyServices` respectively